### PR TITLE
Bastion take2

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -58,6 +58,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
@@ -97,3 +98,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 )
 
-// RESTStorage is a generic interface for RESTful storage services.
+// Storage is a generic interface for RESTful storage services.
 // Resources which are exported to the RESTful API of apiserver need to implement this interface. It is expected
 // that objects may implement any of the below interfaces.
 type Storage interface {
@@ -57,7 +57,15 @@ type Getter interface {
 // GetterWithOptions is an object that retrieve a named RESTful resource and takes
 // additional options on the get request
 type GetterWithOptions interface {
+	// Get finds a resource in the storage by name and returns it.
+	// Although it can return an arbitrary error value, IsNotFound(err) is true for the
+	// returned error value err when the specified resource is not found.
+	// The options object passed to it is of the same type returned by the NewGetOptions
+	// method.
 	Get(ctx api.Context, name string, options runtime.Object) (runtime.Object, error)
+
+	// NewGetOptions returns an empty options object that will be used to pass
+	// options to the Get method.
 	NewGetOptions() runtime.Object
 }
 
@@ -126,6 +134,7 @@ type CreaterUpdater interface {
 // CreaterUpdater must satisfy the Updater interface.
 var _ Updater = CreaterUpdater(nil)
 
+// Patcher is a storage object that supports both get and update.
 type Patcher interface {
 	Getter
 	Updater
@@ -160,11 +169,12 @@ type Redirector interface {
 // ResourceStreamer is an interface implemented by objects that prefer to be streamed from the server
 // instead of decoded directly.
 type ResourceStreamer interface {
-	// InputStream should return an io.Reader if the provided object supports streaming. The desired
+	// InputStream should return an io.ReadCloser if the provided object supports streaming. The desired
 	// api version and a accept header (may be empty) are passed to the call. If no error occurs,
-	// the caller may return a content type string with the reader that indicates the type of the
-	// stream.
-	InputStream(apiVersion, acceptHeader string) (io.ReadCloser, string, error)
+	// the caller may return a flag indicating whether the result should be flushed as writes occur
+	// and a content type string that indicates the type of the stream.
+	// If a null stream is returned, a StatusNoContent response wil be generated.
+	InputStream(apiVersion, acceptHeader string) (stream io.ReadCloser, flush bool, mimeType string, err error)
 }
 
 // StorageMetadata is an optional interface that callers can implement to provide additional

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -54,6 +54,13 @@ type Getter interface {
 	Get(ctx api.Context, name string) (runtime.Object, error)
 }
 
+// GetterWithOptions is an object that retrieve a named RESTful resource and takes
+// additional options on the get request
+type GetterWithOptions interface {
+	Get(ctx api.Context, name string, options runtime.Object) (runtime.Object, error)
+	NewGetOptions() runtime.Object
+}
+
 // Deleter is an object that can delete a named RESTful resource.
 type Deleter interface {
 	// Delete finds a resource in the storage and deletes it.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1234,10 +1234,10 @@ type PodLogOptions struct {
 	TypeMeta `json:",inline"`
 
 	// Container for which to return logs
-	Container string `json:"container" description:"the container for which to stream logs; defaults to first container in pod"`
+	Container string
 
 	// If true, follow the logs for the pod
-	Follow bool `json:"follow" description:"follow the log stream of the pod; defaults to false"`
+	Follow bool
 }
 
 // Status is a return value for calls that don't return other objects.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1229,6 +1229,17 @@ type ListOptions struct {
 	ResourceVersion string
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container" description:"the container for which to stream logs; defaults to first container in pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -65,6 +65,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
@@ -104,3 +105,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1081,6 +1081,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container" description:"the container for which to stream logs; defaults to first container in pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -65,6 +65,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
@@ -104,3 +105,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1095,6 +1095,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container" description:"the container for which to stream logs; defaults to first container in pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 // TODO: this could go in apiserver, but I'm including it here so clients needn't
 // import both.

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -59,6 +59,7 @@ func init() {
 		&PersistentVolumeClaimList{},
 		&DeleteOptions{},
 		&ListOptions{},
+		&PodLogOptions{},
 	)
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
@@ -98,3 +99,4 @@ func (*PersistentVolumeClaim) IsAnAPIObject()     {}
 func (*PersistentVolumeClaimList) IsAnAPIObject() {}
 func (*DeleteOptions) IsAnAPIObject()             {}
 func (*ListOptions) IsAnAPIObject()               {}
+func (*PodLogOptions) IsAnAPIObject()             {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1216,6 +1216,17 @@ type ListOptions struct {
 	ResourceVersion string `json:"resourceVersion" description:"when specified with a watch call, shows changes that occur after that particular version of a resource; defaults to changes from the beginning of history"`
 }
 
+// PodLogOptions is the query options for a Pod's logs REST call
+type PodLogOptions struct {
+	TypeMeta `json:",inline"`
+
+	// Container for which to return logs
+	Container string `json:"container" description:"the container for which to stream logs; defaults to first container in pod"`
+
+	// If true, follow the logs for the pod
+	Follow bool `json:"follow" description:"follow the log stream of the pod; defaults to false"`
+}
+
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -222,7 +222,8 @@ func write(statusCode int, apiVersion string, codec runtime.Codec, object runtim
 		}
 		w.Header().Set("Content-Type", contentType)
 		w.WriteHeader(statusCode)
-		io.Copy(w, out)
+		fw := util.NewFlushWriter(w)
+		io.Copy(fw, out)
 		return
 	}
 	writeJSON(statusCode, codec, object, w)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/flushwriter"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
 
 	"github.com/emicklei/go-restful"
@@ -211,9 +212,14 @@ func APIVersionHandler(versions ...string) restful.RouteFunction {
 // be "application/octet-stream". All other objects are sent to standard JSON serialization.
 func write(statusCode int, apiVersion string, codec runtime.Codec, object runtime.Object, w http.ResponseWriter, req *http.Request) {
 	if stream, ok := object.(rest.ResourceStreamer); ok {
-		out, contentType, err := stream.InputStream(apiVersion, req.Header.Get("Accept"))
+		out, flush, contentType, err := stream.InputStream(apiVersion, req.Header.Get("Accept"))
 		if err != nil {
 			errorJSONFatal(err, codec, w)
+			return
+		}
+		if out == nil {
+			// No output provided - return StatusNoContent
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		defer out.Close()
@@ -222,8 +228,11 @@ func write(statusCode int, apiVersion string, codec runtime.Codec, object runtim
 		}
 		w.Header().Set("Content-Type", contentType)
 		w.WriteHeader(statusCode)
-		fw := util.NewFlushWriter(w)
-		io.Copy(fw, out)
+		writer := w.(io.Writer)
+		if flush {
+			writer = flushwriter.New(w)
+		}
+		io.Copy(writer, out)
 		return
 	}
 	writeJSON(statusCode, codec, object, w)

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -73,8 +73,12 @@ type RequestScope struct {
 	ServerAPIVersion string
 }
 
+// getterFunc performs a get request with the given context and object name. The request
+// may be used to deserialize an options object to pass to the getter.
 type getterFunc func(ctx api.Context, name string, req *restful.Request) (runtime.Object, error)
 
+// getResourceHandler is an HTTP handler function for get requests. It delegates to the
+// passed-in getterFunc to perform the actual get.
 func getResourceHandler(scope RequestScope, getter getterFunc) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
 		w := res.ResponseWriter

--- a/pkg/kubelet/handlers.go
+++ b/pkg/kubelet/handlers.go
@@ -18,9 +18,7 @@ package kubelet
 
 import (
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"strconv"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -94,22 +92,4 @@ func (h *httpActionHandler) Run(podFullName string, uid types.UID, container *ap
 	url := fmt.Sprintf("http://%s/%s", net.JoinHostPort(host, strconv.Itoa(port)), handler.HTTPGet.Path)
 	_, err := h.client.Get(url)
 	return err
-}
-
-// FlushWriter provides wrapper for responseWriter with HTTP streaming capabilities
-type FlushWriter struct {
-	flusher http.Flusher
-	writer  io.Writer
-}
-
-// Write is a FlushWriter implementation of the io.Writer that sends any buffered data to the client.
-func (fw *FlushWriter) Write(p []byte) (n int, err error) {
-	n, err = fw.writer.Write(p)
-	if err != nil {
-		return
-	}
-	if fw.flusher != nil {
-		fw.flusher.Flush()
-	}
-	return
 }

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -38,7 +38,7 @@ import (
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/flushwriter"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	"github.com/golang/glog"
@@ -248,7 +248,7 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 	if _, ok := w.(http.Flusher); !ok {
 		s.error(w, fmt.Errorf("unable to convert %v into http.Flusher", w))
 	}
-	fw := util.NewFlushWriter(w)
+	fw := flushwriter.New(w)
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
 	err = s.host.GetKubeletContainerLogs(kubecontainer.GetPodFullName(pod), containerName, tail, follow, fw, fw)

--- a/pkg/kubelet/server.go
+++ b/pkg/kubelet/server.go
@@ -38,6 +38,7 @@ import (
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy"
 	"github.com/golang/glog"
@@ -244,15 +245,13 @@ func (s *Server) handleContainerLogs(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	fw := FlushWriter{writer: w}
-	if flusher, ok := fw.writer.(http.Flusher); ok {
-		fw.flusher = flusher
-	} else {
-		s.error(w, fmt.Errorf("unable to convert %v into http.Flusher", fw))
+	if _, ok := w.(http.Flusher); !ok {
+		s.error(w, fmt.Errorf("unable to convert %v into http.Flusher", w))
 	}
+	fw := util.NewFlushWriter(w)
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	err = s.host.GetKubeletContainerLogs(kubecontainer.GetPodFullName(pod), containerName, tail, follow, &fw, &fw)
+	err = s.host.GetKubeletContainerLogs(kubecontainer.GetPodFullName(pod), containerName, tail, follow, fw, fw)
 	if err != nil {
 		s.error(w, err)
 		return

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -355,8 +355,8 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 
 // init initializes master.
 func (m *Master) init(c *Config) {
-	podStorage, bindingStorage, podStatusStorage := podetcd.NewStorage(c.EtcdHelper)
-	podRegistry := pod.NewRegistry(podStorage)
+	podStorage := podetcd.NewStorage(c.EtcdHelper)
+	podRegistry := pod.NewRegistry(podStorage.Pod)
 
 	eventRegistry := event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds()))
 	limitRangeRegistry := limitrange.NewEtcdRegistry(c.EtcdHelper)
@@ -381,10 +381,10 @@ func (m *Master) init(c *Config) {
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
-		"pods":         podStorage,
-		"pods/status":  podStatusStorage,
-		"pods/binding": bindingStorage,
-		"bindings":     bindingStorage,
+		"pods":         podStorage.Pod,
+		"pods/status":  podStorage.Status,
+		"pods/binding": podStorage.Binding,
+		"bindings":     podStorage.Binding,
 
 		"replicationControllers": controllerStorage,
 		"services":               service.NewStorage(m.serviceRegistry, c.Cloud, m.nodeRegistry, m.endpointRegistry, m.portalNet, c.ClusterName),

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -355,7 +355,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 
 // init initializes master.
 func (m *Master) init(c *Config) {
-	podStorage := podetcd.NewStorage(c.EtcdHelper)
+	podStorage := podetcd.NewStorage(c.EtcdHelper, c.KubeletClient)
 	podRegistry := pod.NewRegistry(podStorage.Pod)
 
 	eventRegistry := event.NewEtcdRegistry(c.EtcdHelper, uint64(c.EventTTL.Seconds()))

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -383,6 +383,7 @@ func (m *Master) init(c *Config) {
 	m.storage = map[string]rest.Storage{
 		"pods":         podStorage.Pod,
 		"pods/status":  podStorage.Status,
+		"pods/log":     podStorage.Log,
 		"pods/binding": podStorage.Binding,
 		"bindings":     podStorage.Binding,
 

--- a/pkg/registry/generic/rest/doc.go
+++ b/pkg/registry/generic/rest/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rest has generic implementations of resources used for
+// REST responses
+package rest

--- a/pkg/registry/generic/rest/streamer.go
+++ b/pkg/registry/generic/rest/streamer.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// LocationStreamer is a resource that streams the contents of a particular
+// location URL
+type LocationStreamer struct {
+	Location    *url.URL
+	Transport   http.RoundTripper
+	ContentType string
+}
+
+// IsAnAPIObject marks this object as a runtime.Object
+func (*LocationStreamer) IsAnAPIObject() {}
+
+// InputStream returns a stream with the contents of the URL location
+func (s *LocationStreamer) InputStream(apiVersion, acceptHeader string) (io.ReadCloser, string, error) {
+	transport := s.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(s.Location.String())
+	if err != nil {
+		return nil, "", err
+	}
+	contentType := s.ContentType
+	if len(contentType) == 0 {
+		contentType = resp.Header.Get("Content-Type")
+		if len(contentType) > 0 {
+			contentType = strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
+		}
+	}
+	return resp.Body, contentType, nil
+}

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -35,13 +35,20 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 )
 
-// rest implements a RESTStorage for pods against etcd
+// PodStorage includes storage for pods and all sub resources
+type PodStorage struct {
+	Pod     *REST
+	Binding *BindingREST
+	Status  *StatusREST
+}
+
+// REST implements a RESTStorage for pods against etcd
 type REST struct {
 	etcdgeneric.Etcd
 }
 
 // NewStorage returns a RESTStorage object that will work against pods.
-func NewStorage(h tools.EtcdHelper) (*REST, *BindingREST, *StatusREST) {
+func NewStorage(h tools.EtcdHelper) PodStorage {
 	prefix := "/registry/pods"
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Pod{} },
@@ -74,7 +81,11 @@ func NewStorage(h tools.EtcdHelper) (*REST, *BindingREST, *StatusREST) {
 
 	statusStore.UpdateStrategy = pod.StatusStrategy
 
-	return &REST{*store}, &BindingREST{store: store}, &StatusREST{store: &statusStore}
+	return PodStorage{
+		Pod:     &REST{*store},
+		Binding: &BindingREST{store: store},
+		Status:  &StatusREST{store: &statusStore},
+	}
 }
 
 // Implement Redirector.
@@ -90,6 +101,7 @@ type BindingREST struct {
 	store *etcdgeneric.Etcd
 }
 
+// New creates a new binding resource
 func (r *BindingREST) New() runtime.Object {
 	return &api.Binding{}
 }
@@ -166,6 +178,7 @@ type StatusREST struct {
 	store *etcdgeneric.Etcd
 }
 
+// New creates a new pod resource
 func (r *StatusREST) New() runtime.Object {
 	return &api.Pod{}
 }

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -217,6 +217,7 @@ func (r *LogREST) Get(ctx api.Context, name string, opts runtime.Object) (runtim
 		Location:    location,
 		Transport:   transport,
 		ContentType: "text/plain",
+		Flush:       logOpts.Follow,
 	}, nil
 }
 

--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -40,6 +40,7 @@ type PodStorage struct {
 	Pod     *REST
 	Binding *BindingREST
 	Status  *StatusREST
+	Log     *LogREST
 }
 
 // REST implements a RESTStorage for pods against etcd
@@ -85,6 +86,7 @@ func NewStorage(h tools.EtcdHelper) PodStorage {
 		Pod:     &REST{*store},
 		Binding: &BindingREST{store: store},
 		Status:  &StatusREST{store: &statusStore},
+		Log:     &LogREST{store: store},
 	}
 }
 
@@ -186,4 +188,14 @@ func (r *StatusREST) New() runtime.Object {
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, obj)
+}
+
+// LogREST implements the log endpoint for a Pod
+type LogREST struct {
+	store *etcdgeneric.Etcd
+}
+
+// New creates a new Pod log options object
+func (r *LogREST) New() runtime.Object {
+	return &api.PodLogOptions{}
 }

--- a/pkg/registry/pod/rest.go
+++ b/pkg/registry/pod/rest.go
@@ -186,7 +186,7 @@ func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.U
 }
 
 // LogLocation returns a the log URL for a pod container. If container name is blank, the first container is used
-func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ctx api.Context, name, container string) (*url.URL, http.RoundTripper, error) {
+func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ctx api.Context, name string, opts *api.PodLogOptions) (*url.URL, http.RoundTripper, error) {
 
 	pod, err := getPod(getter, ctx, name)
 	if err != nil {
@@ -194,6 +194,7 @@ func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ct
 	}
 
 	// Try to figure out a container
+	container := opts.Container
 	if container == "" {
 		if len(pod.Spec.Containers) > 0 {
 			container = pod.Spec.Containers[0].Name
@@ -211,5 +212,8 @@ func LogLocation(getter ResourceGetter, connInfo client.ConnectionInfoGetter, ct
 	}
 	logURL := fmt.Sprintf("%s://%s:%d/containerLogs/%s/%s/%s", nodeScheme, nodeHost, nodePort, pod.Namespace, name, container)
 	loc, _ := url.Parse(logURL)
+	if opts.Follow {
+		loc.RawQuery = "follow=true"
+	}
 	return loc, nodeTransport, nil
 }

--- a/pkg/util/flusher.go
+++ b/pkg/util/flusher.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"io"
+	"net/http"
+)
+
+// NewFlushWriter wraps an io.Writer into a writer that flushes after every write if
+// the Flusher interface is implemented
+func NewFlushWriter(w io.Writer) io.Writer {
+	fw := &flushWriter{
+		writer: w,
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		fw.flusher = flusher
+	}
+	return fw
+}
+
+// flushWriter provides wrapper for responseWriter with HTTP streaming capabilities
+type flushWriter struct {
+	flusher http.Flusher
+	writer  io.Writer
+}
+
+// Write is a FlushWriter implementation of the io.Writer that sends any buffered data to the client.
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.writer.Write(p)
+	if err != nil {
+		return
+	}
+	if fw.flusher != nil {
+		fw.flusher.Flush()
+	}
+	return
+}

--- a/pkg/util/flushwriter/writer.go
+++ b/pkg/util/flushwriter/writer.go
@@ -1,13 +1,13 @@
-package util
+package flushwriter
 
 import (
 	"io"
 	"net/http"
 )
 
-// NewFlushWriter wraps an io.Writer into a writer that flushes after every write if
-// the Flusher interface is implemented
-func NewFlushWriter(w io.Writer) io.Writer {
+// New wraps an io.Writer into a writer that flushes after every write if
+// the writer implements the Flusher interface.
+func New(w io.Writer) io.Writer {
 	fw := &flushWriter{
 		writer: w,
 	}
@@ -23,7 +23,8 @@ type flushWriter struct {
 	writer  io.Writer
 }
 
-// Write is a FlushWriter implementation of the io.Writer that sends any buffered data to the client.
+// Write is a FlushWriter implementation of the io.Writer that sends any buffered
+// data to the client.
 func (fw *flushWriter) Write(p []byte) (n int, err error) {
 	n, err = fw.writer.Write(p)
 	if err != nil {


### PR DESCRIPTION
@smarterclayton - this is my latest implementation of the pod log resource. The ResourceStreamer interface works beautifully for a one shot fetch of the log. However, it won't work as soon as I want to do a follow. For that I need a httputil.ReverseProxy. So I end up having to do something like the Connect method we talked about even for logs. Any thoughts?
